### PR TITLE
refactor: error handling uses exceptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import 'dotenv/config'
 
 const greeter = (name = process.env.GREETING) => {
-  if (typeof name !== 'string') return { }
+  if (typeof name !== 'string') {
+    throw new TypeError('string expected, got ' + typeof name)
+  }
   return { greeting: `Hello, ${name.charAt(0).toUpperCase() + name.slice(1)}!` }
 }
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -25,13 +25,11 @@ describe('index test', () => {
     same(response, { greeting: 'Hello, 🦉!' })
   })
 
-  test('should return an empty object { }', async () => {
-    const response = greeter(123)
-    same(response, { })
+  test('should throw TypeError', async () => {
+    assert.throws(greeter.bind(greeter, 123), TypeError('string expected, got number'))
   })
 
-  test('should return an empty object { }', async () => {
-    const response = greeter(null)
-    same(response, { })
+  test('should throw TypeError', async () => {
+    assert.throws(greeter.bind(greeter, null), TypeError('string expected, got object'))
   })
 })


### PR DESCRIPTION
Use throw instead of returning an empty object.