### PR TITLE
chore: downgrade dotenv to 7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/mihaur/node-server-template#readme",
   "dependencies": {
-    "dotenv": "^8.1.0"
+    "dotenv": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",


### PR DESCRIPTION
downgrade dotenv to 7.0. to test greenkeeper scanning capabilities